### PR TITLE
Sdv health migration

### DIFF
--- a/src/bash/sdv-health
+++ b/src/bash/sdv-health
@@ -24,8 +24,7 @@ SDV_CAN="can0"
 SDV_CAN_RADAR=""
 
 # Default list of monitored Systemd Services
-#SDV_SERVICES="k3s containerd rauc virtual-kubelet virtual-kubelet-server virtual-kubelet-classic sota-bfb-adapter"
-SDV_SERVICES="containerd rauc"
+SDV_SERVICES="containerd rauc container-management"
 
 # Default list of optional Systemd Services
 #SDV_SERVICES_OPT="vehicle-api mosquitto"

--- a/src/bash/sdv-health
+++ b/src/bash/sdv-health
@@ -235,9 +235,9 @@ cm_check_logging_type ()
 
 cm_get_container_logs () # get the last n (following tail syntax) lines of a container's logs by name
 {
-	local CONT_ID=$1
+	local CONT_NAME=$1
 	local LOG_MAX_LINES=$2
-	CONT_ID=$(cm_get_container_id $CONT_ID) 	
+	CONT_ID=$(cm_get_container_id $CONT_NAME) 	
 	if [ $CONT_ID ]; then
 		LOGGING_TYPE=$(cm_check_logging_type $CONT_ID)
 		if [ $LOGGING_TYPE="json-file" ]; then # according to kanto docs logging type is either "json-file" (to json.log) or "none"

--- a/src/bash/sdv-health
+++ b/src/bash/sdv-health
@@ -143,7 +143,6 @@ prefix()
 	done
 }
 
-
 check_unix_sock() 
 {
 	local socket="$1"
@@ -221,7 +220,6 @@ check_cloudconnector_deviceid()
 		printf -- "$TEXT_FAIL\t (Mosquitto unavailable)\n"
 	fi
 }
-
 
 cm_get_container_id ()
 {

--- a/src/bash/sdv-health
+++ b/src/bash/sdv-health
@@ -25,15 +25,14 @@ SDV_CAN_RADAR=""
 
 # Default list of monitored Systemd Services
 #SDV_SERVICES="k3s containerd rauc virtual-kubelet virtual-kubelet-server virtual-kubelet-classic sota-bfb-adapter"
-SDV_SERVICES="k3s containerd rauc"
+SDV_SERVICES="containerd rauc"
 
 # Default list of optional Systemd Services
 #SDV_SERVICES_OPT="vehicle-api mosquitto"
 SDV_SERVICES_OPT="sshd.socket systemd-networkd systemd-timesyncd"
 
 # Default list of requred SDV Docker containers
-SDV_PODS="mosquitto cloud-connector seat-adjuster-app vehicle-update-manager vehicledatabroker seatservice feedercan dapr-operator dapr-sidecar-injector otelcol-sdv-exporter otelcol-sdv-agent selfupdateagent"
-KANTO_CM_CONTAINERS=$SDV_PODS
+KANTO_CM_CONTAINERS="mosquitto cloud-connector seat-adjuster-app vehicle-update-manager vehicledatabroker seatservice feedercan dapr-operator dapr-sidecar-injector otelcol-sdv-exporter otelcol-sdv-agent selfupdateagent"
 # Change internet connectivity check host
 SDV_PING_HOST="1.1.1.1"
 
@@ -51,10 +50,12 @@ KUBECTL_CMD="kubectl"
 # systemctl exec
 SYSTEMCTL_CMD="systemctl"
 
-# kanto exec
+# kanto paths
 KANTO_CMD="kanto-cm"
+KANTO_CM_HOME_DIR=/var/lib/container-management
+KANTO_CM_LOG_FILE=json.log
 KANTO_SOCK=/run/container-management/container-management.sock
-
+KANTO_LOG_LINES=20
 
 COL_NC='\e[39m'
 COL_RED='\e[31m'
@@ -212,7 +213,6 @@ check_network()
 {
 	local PORTS=`sudo netstat -tnl 2>/dev/null | grep tcp | awk '{ print $4 }' | sort`
 	printf -- "  * %-23s : %s\n" "OpenSSH" "$( port_grep "$PORTS" 22 true  )"
-	printf -- "  * %-23s : %s\n" "Kubernetes API" "$( port_grep "$PORTS" 6444 true  )"
 	printf -- "  * %-23s : %s\n" "Kanto CM" "$(check_unix_sock "$KANTO_SOCK" true  )"
 	printf -- "  * %-23s : %s\n" "Mosquitto Server" "$( port_grep "$PORTS" 1883 true  )"
 }
@@ -271,13 +271,39 @@ check_cloudconnector_deviceid()
 	fi
 }
 
+
+cm_get_container_id ()
+{
+	local CONT_NAME=$1
+	${KANTO_CMD} get -n $CONT_NAME 2>/dev/null | jq -r " .container_id" 
+}
+
+cm_check_logging_type ()
+{
+	local CONT_ID=$1
+	${KANTO_CMD} get -n databroker | jq -r " .host_config.log_config.driver_config.type"
+}
+
+cm_get_container_logs () # get the last n (following tail syntax) lines of a container's logs by name
+{
+	local CONT_ID=$1
+	local LOG_MAX_LINES=$2
+	CONT_ID=$(cm_get_container_id $CONT_ID) 	
+	if [ $CONT_ID ]; then
+		LOGGING_TYPE=$(cm_check_logging_type $CONT_ID)
+		if [ $LOGGING_TYPE="json-file" ]; then # according to kanto docs logging type is either "json-file" (to json.log) or "none"
+			tail -n $LOG_MAX_LINES ${KANTO_CM_HOME_DIR}/containers/${CONT_ID}/${KANTO_CM_LOG_FILE}
+		fi
+	fi
+}
+
 dump_logs()
 {
-	if [ -n "$SDV_PODS" ]; then
+	if [ -n "$KANTO_CM_CONTAINERS" ]; then
 		printf -- "\n${COL_WHITE}************ [Container logs] **********${COL_NC}\n\n"
 
-		for pod in $SDV_PODS; do
-			check_pod_logs "${pod}" "${pod}"
+		for pod in $KANTO_CM_CONTAINERS; do
+			cm_get_container_logs "${pod}" $KANTO_LOG_LINES # get the last $KANTO_LOG_LINES lines of the log
 			printf -- "\n"
 		done
 	fi
@@ -353,7 +379,6 @@ fi
 ######################################################
 
 [ -n "$DUMP_LOGS" ] && dump_logs
-
 printf -- "${COL_WHITE}[SDV Info]${COL_NC}\n"
 # get info values
 source /etc/os-release
@@ -384,37 +409,6 @@ if [ -n "$SDV_SERVICES_OPT" ]; then
 	for service in $SDV_SERVICES_OPT; do
 		printf '  * %-23s : %s\n' "${service}" "$( check_service ${service} false )"
 	done
-fi
-
-K3S_IS_ACTIVE=$(systemctl is-active k3s)
-if [ -n "$SDV_PODS" ]; then
-	printf -- "$SEPARATOR\n"
-
-	printf -- "${COL_WHITE}[SDV Pods]${COL_NC}\n"
-	if [ $K3S_IS_ACTIVE ]; then
-
-		ALL_PODS=$(kubectl get pods -A -o custom-columns=:metadata.name,:status.phase --no-headers=true --request-timeout='20s' --sort-by=metadata.name)
-		for expectedPod in $SDV_PODS; do
-			while IFS= read -ra line ; do
-				#echo $line;
-				IFS=' ' read -ra ARR <<< $line
-				#printf '  * %-23s : %s\n' "${ARR[0]}" "${ARR[1]}"
-				pod=${ARR[0]}
-				status=${ARR[1]}
-
-				if [[ "$pod" == *"$expectedPod"* ]]; then
-					if [ "$status" = "Running" ] || [ "$status" = "Succeeded" ]; then
-						printf "  * %-40s : $TEXT_OK\n" "${pod}"
-					else
-						printf "  * %-40s : $TEXT_FAIL (%s)\n" "${pod}" "$status"
-					fi
-				fi
-
-			done <<< "$ALL_PODS"
-		done
-	else
-		printf "  * %-40s : $TEXT_FAIL (%s)\n" "Kubernetes" "Unavailable"
-	fi
 fi
 
 CM_STATUS=$(systemctl is-active container-management)

--- a/src/bash/sdv-health
+++ b/src/bash/sdv-health
@@ -45,8 +45,6 @@ VERBOSE=0
 
 ### CONSTANTS below
 
-# kubectl exec
-KUBECTL_CMD="kubectl"
 # systemctl exec
 SYSTEMCTL_CMD="systemctl"
 
@@ -55,7 +53,7 @@ KANTO_CMD="kanto-cm"
 KANTO_CM_HOME_DIR=/var/lib/container-management
 KANTO_CM_LOG_FILE=json.log
 KANTO_SOCK=/run/container-management/container-management.sock
-KANTO_LOG_LINES=20
+KANTO_LOG_LINES=$LOG_LINES
 
 COL_NC='\e[39m'
 COL_RED='\e[31m'
@@ -95,30 +93,6 @@ check_service()
 	fi
 }
 
-check_pod()
-{
-	local pod="$1"
-	local required="$2"
-
-	RESULT=$( $KUBECTL_CMD describe pod $pod 2>/dev/null )
-	local status=$( echo "$RESULT" | grep "Status:"  | cut -d ':' -f 2 | xargs )
-	local ready=$(  echo "$RESULT" | grep "  Ready " | awk '{ print $2 }' )
-
-	if [ "$status" = "Running" ] && [ "$ready" = "True" ]; then
-		printf -- "$TEXT_OK\n"
-	else
-		local err_msg="(N/A)"
-		if [ -n "$status" ] || [ -n "$ready" ]; then
-			err_msg="(Status: \"$status\", Ready: $ready)"
-		fi
-		if [ "$required" = "true" ]; then
-			printf -- "$TEXT_FAIL\t $err_msg"
-		else
-			printf -- "$TEXT_NOTICE\t $err_msg"
-		fi
-	fi
-}
-
 check_rc() {
 	local STATUS=$( $* 2>&1 1>/dev/null )
 	rc=$?
@@ -129,28 +103,6 @@ check_rc() {
 		[ -z "$STATUS" ] && STATUS="error: $rc"
 		printf -- "$TEXT_FAIL\t %s\n" "($STATUS)"
 	fi
-}
-
-check_pod_logs()
-{
-	local pod="$1"
-	local prefix="$2"
-
-	# 1st find containers for pod, then tail each container's logs
-	printf -- "$SEPARATOR\n" | prefix "[$prefix]"
-	printf -- "${COL_YELLOW}$ $KUBECTL_CMD get pod $pod -o jsonpath=\"{.spec.containers[*].name}\" ${COL_NC}\n" | prefix "[$prefix]"
-	local containers=$( $KUBECTL_CMD get pod $pod -o jsonpath="{.spec.containers[*].name}" )
-
-	if [ -z "$containers" ]; then
-		printf -- "No contaiers in $pod" | prefix "[$prefix]"
-		return 1
-	fi
-	for c in $containers; do
-		printf -- "${COL_YELLOW}$ $KUBECTL_CMD logs $pod -c $c --tail $LOG_LINES ${COL_NC}\n" | prefix "[$prefix]"
-		$KUBECTL_CMD logs $pod -c $c --tail $LOG_LINES | prefix "[$prefix/$c]"
-		printf -- "\n" | prefix "[$prefix]"
-	done
-	printf -- "$SEPARATOR\n" | prefix "[$prefix]"
 }
 
 check_service_logs()
@@ -302,8 +254,8 @@ dump_logs()
 	if [ -n "$KANTO_CM_CONTAINERS" ]; then
 		printf -- "\n${COL_WHITE}************ [Container logs] **********${COL_NC}\n\n"
 
-		for pod in $KANTO_CM_CONTAINERS; do
-			cm_get_container_logs "${pod}" $KANTO_LOG_LINES # get the last $KANTO_LOG_LINES lines of the log
+		for container in $KANTO_CM_CONTAINERS; do
+			cm_get_container_logs "${container}" $KANTO_LOG_LINES # get the last $KANTO_LOG_LINES lines of the log
 			printf -- "\n"
 		done
 	fi


### PR DESCRIPTION
K3s references and functionality removed from sdv health. Container loggin functionality for kanto-cm added. Dump logs now rewritten for kanto-cm. 